### PR TITLE
Test: Nullable String

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ gitter:
 clean:
 	rm doc
 	rm gitter
+
+test:
+	go test ./...

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -52,7 +52,7 @@ func NewCRDer(data []byte, m ...Modifier) (*CRDer, error) {
 	internal := &apiextensions.CustomResourceDefinition{}
 	if errV1Beta1 := convertV1Beta1ToInternal(data, internal, m...); errV1Beta1 != nil {
 		if errV1 := convertV1ToInternal(data, internal, m...); errV1 != nil {
-			return nil, fmt.Errorf("conversion unsuccessful: %s, %s", errV1Beta1, errV1)
+			return nil, fmt.Errorf("conversion unsuccessful:\n\n V1BETA: %s \n\n V1: %s", errV1Beta1, errV1)
 		}
 	}
 

--- a/pkg/crd/stackablecrd.yaml
+++ b/pkg/crd/stackablecrd.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabs.example.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+  - name: v1
+    # Each version can be enabled/disabled by Served flag.
+    served: true
+    # One and only one version must be marked as the storage version.
+    storage: true
+    # A schema is required
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          credentialsSecret:
+            default: ''
+            nullable: true
+            type: string
+          host:
+            type: string
+            default: 'bla'
+          port:
+            type: string
+            default: 'blabla'
+        required:
+          - credentialsSecret
+  # The conversion section is introduced in Kubernetes 1.13+ with a default value of
+  # None conversion (strategy sub-field set to None).
+  conversion:
+    # None conversion assumes the same schema for all versions and only sets the apiVersion
+    # field of custom resources to the proper value
+    strategy: None
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabs
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontab
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTab
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - ct


### PR DESCRIPTION
Related to https://github.com/stackabletech/crddocs/issues/5

Trying to replicate one of the validation errors produced for the airflow-operator crd around nullable, required, default-provided string fields.

The test case does not fail as expected.