### PR TITLE
fix: Adjust Go version in go.mod file

### DIFF
--- a/docs-generator/go.mod
+++ b/docs-generator/go.mod
@@ -1,6 +1,6 @@
 module docs-generator
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/go-git/go-git/v5 v5.12.0


### PR DESCRIPTION
This should fix the following error:

```
go: download go1.23 for linux/amd64: toolchain not available
```

_Encountered in Netlify Deploy Log_