### PR TITLE
feat: Look at extra path to find CRDs

### DIFF
--- a/docs-generator/gitter/gitter.go
+++ b/docs-generator/gitter/gitter.go
@@ -156,10 +156,11 @@ func Index(db *sql.DB, repo string, tag string) error {
 
 func getCRDsFromTag(dir string, w *git.Worktree) (map[string]models.RepoCRD, error) {
 	reg := regexp.MustCompile("kind: CustomResourceDefinition")
-	regPath := regexp.MustCompile(`^deploy/helm/.*\.yaml`)
+	helmPathRegex := regexp.MustCompile(`^deploy/helm/.*\.yaml`)
+	extraPathRegex := regexp.MustCompile(`^extra/.*\.yaml`)
 	g, _ := w.Grep(&git.GrepOptions{
 		Patterns:  []*regexp.Regexp{reg},
-		PathSpecs: []*regexp.Regexp{regPath},
+		PathSpecs: []*regexp.Regexp{helmPathRegex, extraPathRegex},
 	})
 	repoCRDs := map[string]models.RepoCRD{}
 	files := getYAMLs(g, dir)


### PR DESCRIPTION
With this PR, the `gitter` component additionally looks at the `extra/` path to find CRDs. This is currently only needed for the secret-operator beginning with SDP 25.11.0.