### PR TITLE
fix: Remove null values from enums

### DIFF
--- a/docs-generator/pkg/crd/crd.go
+++ b/docs-generator/pkg/crd/crd.go
@@ -103,7 +103,7 @@ func (c *CRDer) Validate(data []byte) error {
 
 // Remove null values from enums
 //
-// kube-rs 2.0.1 appends a null to all enums which cannot be processed by this module.
+// kube-rs 2.0.1 appends a null to all enums. These null values cannot be processed by this module.
 func removeNullsFromEnums(schema *v1.JSONSchemaProps) {
 	if schema.Enum != nil {
 		schema.Enum = slices.DeleteFunc(schema.Enum, func(entry v1.JSON) bool {

--- a/docs-generator/pkg/crd/crd.go
+++ b/docs-generator/pkg/crd/crd.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	servervalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
@@ -100,11 +101,44 @@ func (c *CRDer) Validate(data []byte) error {
 	return nil
 }
 
+// Remove null values from enums
+//
+// kube-rs 2.0.1 appends a null to all enums which cannot be processed by this module.
+func removeNullsFromEnums(schema *v1.JSONSchemaProps) {
+	if schema.Enum != nil {
+		schema.Enum = slices.DeleteFunc(schema.Enum, func(entry v1.JSON) bool {
+			return entry.Size() == 0
+		})
+	}
+
+	if schema.Properties != nil {
+		for key, value := range schema.Properties {
+			removeNullsFromEnums(&value)
+			schema.Properties[key] = value
+		}
+	}
+
+	if schema.AdditionalProperties != nil && schema.AdditionalProperties.Schema != nil {
+		removeNullsFromEnums(schema.AdditionalProperties.Schema)
+	}
+}
+
+func fixCrd(crd *v1.CustomResourceDefinition) {
+	for _, version := range crd.Spec.Versions {
+		if version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
+			removeNullsFromEnums(version.Schema.OpenAPIV3Schema)
+		}
+	}
+}
+
 func convertV1ToInternal(data []byte, internal *apiextensions.CustomResourceDefinition, mods ...Modifier) error {
 	crd := &v1.CustomResourceDefinition{}
 	if err := yaml.Unmarshal(data, crd); err != nil {
 		return err
 	}
+
+	fixCrd(crd)
+
 	v1.SetDefaults_CustomResourceDefinition(crd)
 	if err := v1.Convert_v1_CustomResourceDefinition_To_apiextensions_CustomResourceDefinition(crd, internal, nil); err != nil {
 		return err

--- a/docs-generator/pkg/crd/crd_test.go
+++ b/docs-generator/pkg/crd/crd_test.go
@@ -313,6 +313,44 @@ status:
   storedVersions: []
 `)
 
+var crdWithNullInEnum = []byte(`
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nullinenumtests.example.com
+spec:
+  group: example.com
+  names:
+    categories: []
+    kind: NullInEnumTest
+    plural: nullinenumtests
+    singular: nullinenumtest
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns: []
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            root:
+              additionalProperties:
+                properties:
+                  choice:
+                    enum:
+                      - null
+                      - entry1
+                      - null
+                      - entry2
+                      - null
+                    type: string
+                type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+`)
+
 var a = []byte(`
 apiVersion: example.com/v1
 kind: CronTab
@@ -341,6 +379,18 @@ specTemplate:
   reclaimPolicy: Delete
 `)
 
+var c = []byte(`
+---
+apiVersion: example.com/v1
+kind: NullInEnumTest
+metadata:
+  name: null-in-enum-test
+  namespace: test
+root:
+  property:
+    choice: entry1
+`)
+
 func TestValidate(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -364,6 +414,12 @@ func TestValidate(t *testing.T) {
 			name:        "crossplane valid",
 			crd:         crossplane,
 			instance:    b,
+			expectedErr: false,
+		},
+		{
+			name:        "crdWithNullInEnum valid",
+			crd:         crdWithNullInEnum,
+			instance:    c,
 			expectedErr: false,
 		},
 	}


### PR DESCRIPTION
Remove `null` values from enums

kube-rs 2.0.1 appends a `null` to all enums. These enums cannot be processed by this module. In https://github.com/stackabletech/kube-rs/pull/1, the enum generation was fixed, but SDP 25.11 was released without this fix. Therefore, this change removes the `null` values from the CRDs, so that the CRD documentation for SDP 25.11 can be rendered.